### PR TITLE
Add store product catalog

### DIFF
--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const productSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  price: { type: Number, required: true },
+  storeId: { type: mongoose.Schema.Types.ObjectId, ref: 'Store', required: true },
+  stock: { type: Number, required: true, default: 0 }
+});
+
+module.exports = mongoose.model('Product', productSchema);

--- a/backend/routes/stores.js
+++ b/backend/routes/stores.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const Product = require('../models/Product');
+
+const router = express.Router();
+
+// GET /stores/:id/products - list products for a store
+router.get('/:id/products', async (req, res) => {
+  try {
+    const products = await Product.find({ storeId: req.params.id });
+    res.json(products);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,12 +3,14 @@ const mongoose = require('mongoose');
 const dotenv = require('dotenv');
 
 const authRoutes = require('./routes/auth');
+const storeRoutes = require('./routes/stores');
 
 dotenv.config();
 
 const app = express();
 app.use(express.json());
 app.use('/auth', authRoutes);
+app.use('/stores', storeRoutes);
 
 const PORT = process.env.PORT || 3000;
 const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/delivery';

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 import 'register_screen.dart';
+import 'store_selection_screen.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -30,8 +31,12 @@ class _LoginScreenState extends State<LoginScreen> {
       );
 
       if (response.statusCode == 200) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Login successful')),
+        if (!mounted) return;
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (_) => const StoreSelectionScreen(),
+          ),
         );
       } else {
         final message = jsonDecode(response.body)['message'];

--- a/lib/screens/product_catalog_screen.dart
+++ b/lib/screens/product_catalog_screen.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class ProductCatalogScreen extends StatefulWidget {
+  final String storeId;
+  const ProductCatalogScreen({super.key, required this.storeId});
+
+  @override
+  State<ProductCatalogScreen> createState() => _ProductCatalogScreenState();
+}
+
+class _ProductCatalogScreenState extends State<ProductCatalogScreen> {
+  late Future<List<dynamic>> _futureProducts;
+
+  Future<List<dynamic>> _fetchProducts() async {
+    final response = await http
+        .get(Uri.parse('http://localhost:3000/stores/${widget.storeId}/products'));
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as List<dynamic>;
+    } else {
+      throw Exception('Failed to load products');
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _futureProducts = _fetchProducts();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Products')),
+      body: FutureBuilder<List<dynamic>>(
+        future: _futureProducts,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          } else {
+            final products = snapshot.data!;
+            return ListView.builder(
+              itemCount: products.length,
+              itemBuilder: (context, index) {
+                final product = products[index];
+                return ListTile(
+                  title: Text(product['name'] ?? 'Unnamed'),
+                  subtitle: Text('Stock: ${product['stock']}'),
+                );
+              },
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/store_selection_screen.dart
+++ b/lib/screens/store_selection_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import 'product_catalog_screen.dart';
+
+class StoreSelectionScreen extends StatelessWidget {
+  const StoreSelectionScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final stores = [
+      {'id': '1', 'name': 'Store 1'},
+      {'id': '2', 'name': 'Store 2'},
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Select Store')),
+      body: ListView.builder(
+        itemCount: stores.length,
+        itemBuilder: (context, index) {
+          final store = stores[index];
+          return ListTile(
+            title: Text(store['name']!),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ProductCatalogScreen(storeId: store['id']!),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add Product model with store link and stock
- expose `/stores/:id/products` endpoint
- display products per selected store in Flutter app

## Testing
- `npm test`
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a74df995f48331b98c88e28d4a639e